### PR TITLE
Cleaning up the CSS

### DIFF
--- a/src/nitro/commands/build.py
+++ b/src/nitro/commands/build.py
@@ -158,7 +158,9 @@ def build(
                         resp_count += 1
 
                 if resp_count:
-                    verbose(f"Processed {resp_count} HTML file(s) with responsive images")
+                    verbose(
+                        f"Processed {resp_count} HTML file(s) with responsive images"
+                    )
 
             if fingerprint:
                 update("Fingerprinting assets...")
@@ -185,7 +187,9 @@ def build(
             html_files = list(generator.build_dir.rglob("*.html"))
             sitemap_path = generator.build_dir / "sitemap.xml"
             bundler.generate_sitemap(
-                base_url=config.base_url, html_files=html_files, output_path=sitemap_path
+                base_url=config.base_url,
+                html_files=html_files,
+                output_path=sitemap_path,
             )
             verbose(f"Created sitemap.xml with {len(html_files)} URLs")
 

--- a/src/nitro/templates/default/src/pages/index.py
+++ b/src/nitro/templates/default/src/pages/index.py
@@ -8,7 +8,7 @@ from nitro_ui.html import (
     body,
     title,
     meta,
-    style,
+    link,
     main,
     section,
     div,
@@ -22,7 +22,9 @@ from nitro_ui.html import (
 from nitro import Page
 
 # Get version info
-python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+python_version = (
+    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+)
 
 try:
     from nitro import __version__ as nitro_version
@@ -32,200 +34,6 @@ except ImportError:
 
 def render():
     """Render the welcome splash page."""
-
-    # Inline styles for splash page (self-contained)
-    styles = """
-        :root {
-            --primary: #8b5cf6;
-            --primary-dark: #7c3aed;
-            --bg: #0f0f10;
-            --bg-card: #18181b;
-            --text: #fafafa;
-            --text-muted: #a1a1aa;
-            --border: #27272a;
-            --success: #22c55e;
-        }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            background: var(--bg);
-            color: var(--text);
-            min-height: 100vh;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 2rem;
-            line-height: 1.6;
-        }
-
-        .splash {
-            max-width: 640px;
-            width: 100%;
-            text-align: center;
-        }
-
-        .logo {
-            font-size: 4rem;
-            margin-bottom: 0.5rem;
-            filter: drop-shadow(0 0 20px rgba(139, 92, 246, 0.5));
-        }
-
-        .brand {
-            font-size: 2.5rem;
-            font-weight: 800;
-            letter-spacing: -0.03em;
-            background: linear-gradient(135deg, var(--primary) 0%, #ec4899 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            margin-bottom: 0.5rem;
-        }
-
-        .tagline {
-            font-size: 1.25rem;
-            color: var(--text-muted);
-            margin-bottom: 2.5rem;
-        }
-
-        .status {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-            background: var(--bg-card);
-            border: 1px solid var(--border);
-            border-radius: 9999px;
-            padding: 0.5rem 1rem;
-            font-size: 0.875rem;
-            margin-bottom: 3rem;
-        }
-
-        .status-dot {
-            width: 8px;
-            height: 8px;
-            background: var(--success);
-            border-radius: 50%;
-            animation: pulse 2s infinite;
-        }
-
-        @keyframes pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.5; }
-        }
-
-        .card {
-            background: var(--bg-card);
-            border: 1px solid var(--border);
-            border-radius: 16px;
-            padding: 2rem;
-            margin-bottom: 2rem;
-            text-align: left;
-        }
-
-        .card-title {
-            font-size: 0.75rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.1em;
-            color: var(--text-muted);
-            margin-bottom: 1rem;
-        }
-
-        .command {
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-            padding: 0.75rem 0;
-            border-bottom: 1px solid var(--border);
-        }
-
-        .command:last-child {
-            border-bottom: none;
-        }
-
-        .command-icon {
-            font-size: 1.25rem;
-            width: 2rem;
-            text-align: center;
-        }
-
-        .command-text {
-            flex: 1;
-        }
-
-        .command-code {
-            font-family: "SF Mono", "Fira Code", "Consolas", monospace;
-            font-size: 0.9375rem;
-            color: var(--primary);
-        }
-
-        .command-desc {
-            font-size: 0.8125rem;
-            color: var(--text-muted);
-        }
-
-        .info-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 1rem;
-        }
-
-        .info-item {
-            background: var(--bg);
-            border-radius: 8px;
-            padding: 1rem;
-        }
-
-        .info-label {
-            font-size: 0.75rem;
-            color: var(--text-muted);
-            margin-bottom: 0.25rem;
-        }
-
-        .info-value {
-            font-family: "SF Mono", "Fira Code", "Consolas", monospace;
-            font-size: 0.9375rem;
-        }
-
-        .links {
-            display: flex;
-            gap: 1.5rem;
-            justify-content: center;
-            flex-wrap: wrap;
-        }
-
-        .links a {
-            color: var(--text-muted);
-            text-decoration: none;
-            font-size: 0.875rem;
-            transition: color 0.2s;
-        }
-
-        .links a:hover {
-            color: var(--primary);
-        }
-
-        .footer {
-            margin-top: 3rem;
-            color: var(--text-muted);
-            font-size: 0.8125rem;
-        }
-
-        .footer code {
-            background: var(--bg-card);
-            padding: 0.2em 0.5em;
-            border-radius: 4px;
-            font-family: "SF Mono", "Fira Code", "Consolas", monospace;
-        }
-
-        @media (max-width: 480px) {
-            .brand { font-size: 2rem; }
-            .tagline { font-size: 1rem; }
-            .info-grid { grid-template-columns: 1fr; }
-        }
-    """
 
     # Status badge
     status = div(
@@ -242,7 +50,10 @@ def render():
                 span("1", class_name="command-icon"),
                 div(
                     code("src/pages/index.py", class_name="command-code"),
-                    p("Edit this file to customize your home page", class_name="command-desc"),
+                    p(
+                        "Edit this file to customize your home page",
+                        class_name="command-desc",
+                    ),
                     class_name="command-text",
                 ),
                 class_name="command",
@@ -290,9 +101,17 @@ def render():
 
     # Links
     links = div(
-        a("Documentation", href="https://github.com/nitro-sh/nitro-cli", target="_blank"),
+        a(
+            "Documentation",
+            href="https://github.com/nitro-sh/nitro-cli",
+            target="_blank",
+        ),
         a("nitro-ui", href="https://github.com/nitro-sh/nitro-ui", target="_blank"),
-        a("Examples", href="https://github.com/nitro-sh/nitro-cli/tree/main/examples", target="_blank"),
+        a(
+            "Examples",
+            href="https://github.com/nitro-sh/nitro-cli/tree/main/examples",
+            target="_blank",
+        ),
         class_name="links",
     )
 
@@ -310,7 +129,7 @@ def render():
             meta(name="viewport", content="width=device-width, initial-scale=1.0"),
             title("Welcome to Nitro"),
             meta(name="description", content="Your new Nitro project is ready"),
-            style(styles),
+            link(rel="stylesheet", href="/styles/main.css"),
         ),
         body(
             main(

--- a/src/nitro/templates/default/src/styles/main.css
+++ b/src/nitro/templates/default/src/styles/main.css
@@ -1,17 +1,22 @@
 /* Nitro Default Template Styles */
 
+/* ============================================
+   Splash Page (Welcome Screen)
+   ============================================ */
+
 :root {
-  --primary: #6366f1;
-  --primary-dark: #4f46e5;
+  --primary: #8b5cf6;
+  --primary-dark: #7c3aed;
   --secondary: #0ea5e9;
-  --text: #1e293b;
-  --text-muted: #64748b;
-  --bg: #ffffff;
-  --bg-alt: #f8fafc;
-  --border: #e2e8f0;
+  --bg: #0f0f10;
+  --bg-card: #18181b;
+  --text: #fafafa;
+  --text-muted: #a1a1aa;
+  --border: #27272a;
+  --success: #22c55e;
   --radius: 12px;
   --max-width: 1200px;
-  --gradient: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+  --gradient: linear-gradient(135deg, var(--primary) 0%, #ec4899 100%);
 }
 
 * {
@@ -26,10 +31,205 @@ html {
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  color: var(--text);
   background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
   line-height: 1.6;
-  font-size: 16px;
+}
+
+.splash {
+  max-width: 640px;
+  width: 100%;
+  text-align: center;
+}
+
+.logo {
+  font-size: 4rem;
+  margin-bottom: 0.5rem;
+  filter: drop-shadow(0 0 20px rgba(139, 92, 246, 0.5));
+}
+
+.brand {
+  font-size: 2.5rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  background: var(--gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.tagline {
+  font-size: 1.25rem;
+  color: var(--text-muted);
+  margin-bottom: 2.5rem;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  margin-bottom: 3rem;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--success);
+  border-radius: 50%;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  text-align: left;
+}
+
+.card-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.command {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.command:last-child {
+  border-bottom: none;
+}
+
+.command-icon {
+  font-size: 1.25rem;
+  width: 2rem;
+  text-align: center;
+}
+
+.command-text {
+  flex: 1;
+}
+
+.command-code {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 0.9375rem;
+  color: var(--primary);
+}
+
+.command-desc {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.info-item {
+  background: var(--bg);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.info-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.info-value {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 0.9375rem;
+}
+
+.links {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.links a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+.links a:hover {
+  color: var(--primary);
+}
+
+.footer {
+  margin-top: 3rem;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+.footer code {
+  background: var(--bg-card);
+  padding: 0.2em 0.5em;
+  border-radius: 4px;
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+}
+
+@media (max-width: 480px) {
+  .brand { font-size: 2rem; }
+  .tagline { font-size: 1rem; }
+  .info-grid { grid-template-columns: 1fr; }
+}
+
+/* ============================================
+   Light Theme (Marketing Pages)
+   ============================================ */
+
+body.light-theme {
+  background: #ffffff;
+  color: #1e293b;
+  min-height: auto;
+  display: block;
+  padding: 0;
+}
+
+.light-theme {
+  --primary: #6366f1;
+  --primary-dark: #4f46e5;
+  --secondary: #0ea5e9;
+  --text: #1e293b;
+  --text-muted: #64748b;
+  --bg: #ffffff;
+  --bg-alt: #f8fafc;
+  --bg-card: #ffffff;
+  --border: #e2e8f0;
+  --gradient: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
 }
 
 /* Header */
@@ -51,13 +251,15 @@ body {
   align-items: center;
 }
 
-.logo {
+.light-theme .logo {
   font-size: 1.5rem;
   font-weight: 700;
   background: var(--gradient);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  filter: none;
+  margin-bottom: 0;
 }
 
 .nav {
@@ -321,20 +523,22 @@ body {
   margin-bottom: 2rem;
 }
 
-/* Footer */
-.footer {
+/* Light Theme Footer */
+.light-theme .footer {
   border-top: 1px solid var(--border);
   padding: 2rem 1.5rem;
   text-align: center;
   color: var(--text-muted);
+  margin-top: 0;
+  font-size: inherit;
 }
 
-.footer a {
+.light-theme .footer a {
   color: var(--primary);
   text-decoration: none;
 }
 
-.footer a:hover {
+.light-theme .footer a:hover {
   text-decoration: underline;
 }
 

--- a/src/nitro/utils/logger.py
+++ b/src/nitro/utils/logger.py
@@ -183,9 +183,7 @@ def build_complete(stats: dict, elapsed: str) -> None:
         if total < 1024 * 1024
         else f"{total / (1024 * 1024):.1f}MB"
     )
-    console.print(
-        f"\n[green]✓[/] Build complete: {count} files, {size} ({elapsed})"
-    )
+    console.print(f"\n[green]✓[/] Build complete: {count} files, {size} ({elapsed})")
 
 
 def build_summary(stats: dict, elapsed: str) -> None:

--- a/tests/test_bundler.py
+++ b/tests/test_bundler.py
@@ -135,9 +135,7 @@ class TestGenerateSitemap:
             output_path = build_dir / "sitemap.xml"
 
             bundler = Bundler(build_dir)
-            bundler.generate_sitemap(
-                "https://example.com", html_files, output_path
-            )
+            bundler.generate_sitemap("https://example.com", html_files, output_path)
 
             assert output_path.exists()
             content = output_path.read_text()
@@ -158,9 +156,7 @@ class TestGenerateSitemap:
             output_path = build_dir / "sitemap.xml"
 
             bundler = Bundler(build_dir)
-            bundler.generate_sitemap(
-                "https://example.com", html_files, output_path
-            )
+            bundler.generate_sitemap("https://example.com", html_files, output_path)
 
             content = output_path.read_text()
             # Index entry should have 1.0 priority

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,9 @@ class TestNewCommand:
         runner = CliRunner()
         with tempfile.TemporaryDirectory() as tmpdir:
             with runner.isolated_filesystem(temp_dir=tmpdir):
-                result = runner.invoke(main, ["new", "test-project", "--no-git", "--no-install"])
+                result = runner.invoke(
+                    main, ["new", "test-project", "--no-git", "--no-install"]
+                )
 
                 assert result.exit_code == 0
                 assert Path("test-project").exists()
@@ -122,7 +124,9 @@ class TestCleanCommand:
         with tempfile.TemporaryDirectory() as tmpdir:
             with runner.isolated_filesystem(temp_dir=tmpdir):
                 # Create project structure
-                Path("nitro.config.py").write_text("from nitro import Config\nconfig = Config()")
+                Path("nitro.config.py").write_text(
+                    "from nitro import Config\nconfig = Config()"
+                )
                 Path("src/pages").mkdir(parents=True)
                 Path("build").mkdir()
                 (Path("build") / "index.html").write_text("<html></html>")
@@ -142,9 +146,9 @@ class TestInfoCommand:
         with tempfile.TemporaryDirectory() as tmpdir:
             with runner.isolated_filesystem(temp_dir=tmpdir):
                 # Create project structure
-                config_content = '''from nitro import Config
+                config_content = """from nitro import Config
 config = Config(site_name="Test Site", base_url="https://test.com")
-'''
+"""
                 Path("nitro.config.py").write_text(config_content)
                 Path("src/pages").mkdir(parents=True)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,14 +63,16 @@ class TestLoadConfig:
         """Should load config from Python file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "nitro.config.py"
-            config_path.write_text("""
+            config_path.write_text(
+                """
 from nitro import Config
 
 config = Config(
     site_name="Loaded Site",
     base_url="https://loaded.com",
 )
-""")
+"""
+            )
             loaded = load_config(config_path)
 
             assert loaded.site_name == "Loaded Site"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -255,12 +255,14 @@ class TestRenderPage:
 
             # Create a simple page
             page_file = pages_dir / "test.py"
-            page_file.write_text("""
+            page_file.write_text(
+                """
 from nitro.core.page import Page
 
 def render():
     return Page(title="Test", content="<h1>Hello World</h1>")
-""")
+"""
+            )
 
             config = Config()
             renderer = Renderer(config)
@@ -279,14 +281,16 @@ def render():
 
             # Create a page with a mock element
             page_file = pages_dir / "element.py"
-            page_file.write_text("""
+            page_file.write_text(
+                """
 class MockElement:
     def render(self):
         return "<div>Element content</div>"
 
 def render():
     return MockElement()
-""")
+"""
+            )
 
             config = Config()
             renderer = Renderer(config)


### PR DESCRIPTION
This pull request refactors the Nitro default template to move all splash page (welcome screen) styles from inline CSS in `index.py` to an external stylesheet, `main.css`. It also introduces a dark and light theme structure for styles and updates the template to reference the new stylesheet. Additionally, there are several minor formatting improvements and test code cleanups.

**Refactor: Move Splash Page Styles to External CSS and Theme Support**
- Removed the large inline `styles` string from `src/nitro/templates/default/src/pages/index.py` and replaced it with a `<link rel="stylesheet" href="/styles/main.css">` reference, so all splash page styling is now handled in `main.css`. [[1]](diffhunk://#diff-86baf8db2cbebf194d29b2e8dc3fab735281f1554f77f5c8eb578ccf8df55567L36-L229) [[2]](diffhunk://#diff-86baf8db2cbebf194d29b2e8dc3fab735281f1554f77f5c8eb578ccf8df55567L313-R132)
- Added all splash page CSS rules to `src/nitro/templates/default/src/styles/main.css`, including dark and light theme variables, splash layout, and responsive adjustments. This makes the template cleaner and easier to maintain. [[1]](diffhunk://#diff-00e8b6b1c7d23904b837d304bebe4af6731bc486e6ac6a7844c3e5d72b00c390R3-R19) [[2]](diffhunk://#diff-00e8b6b1c7d23904b837d304bebe4af6731bc486e6ac6a7844c3e5d72b00c390L29-R232)
- Implemented `.light-theme` CSS overrides in `main.css` to support both dark and light themes for marketing and splash pages. [[1]](diffhunk://#diff-00e8b6b1c7d23904b837d304bebe4af6731bc486e6ac6a7844c3e5d72b00c390L54-R262) [[2]](diffhunk://#diff-00e8b6b1c7d23904b837d304bebe4af6731bc486e6ac6a7844c3e5d72b00c390L324-R541)

**Template and Code Formatting Improvements**
- Updated imports in `index.py` to use `link` instead of `style` for external CSS, and improved line wrapping for readability. [[1]](diffhunk://#diff-86baf8db2cbebf194d29b2e8dc3fab735281f1554f77f5c8eb578ccf8df55567L11-R11) [[2]](diffhunk://#diff-86baf8db2cbebf194d29b2e8dc3fab735281f1554f77f5c8eb578ccf8df55567L25-R27) [[3]](diffhunk://#diff-86baf8db2cbebf194d29b2e8dc3fab735281f1554f77f5c8eb578ccf8df55567L245-R56) [[4]](diffhunk://#diff-86baf8db2cbebf194d29b2e8dc3fab735281f1554f77f5c8eb578ccf8df55567L293-R114)
- Improved formatting for Python f-strings and function arguments for better readability in several files. [[1]](diffhunk://#diff-800151aece20c1ae0dc72533ae520fde1b926e03e063e3ce596ec08b674f72a1L161-R163) [[2]](diffhunk://#diff-800151aece20c1ae0dc72533ae520fde1b926e03e063e3ce596ec08b674f72a1L188-R192) [[3]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L186-R186)

**Test Code Cleanups**
- Reformatted multiline string literals and function invocations for clarity and consistency in test files. [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL94-R96) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL125-R129) [[3]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL145-R151) [[4]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L66-R75) [[5]](diffhunk://#diff-366efe3372d2a387c5c8e3ecb24408de31aa85cac1eee3ab49833a5fdcf30362L258-R265) [[6]](diffhunk://#diff-366efe3372d2a387c5c8e3ecb24408de31aa85cac1eee3ab49833a5fdcf30362L282-R293) [[7]](diffhunk://#diff-4cd404657dfc263af0e826d32015c634a2e0e727c10a4035c801e525ead6af3bL138-R138) [[8]](diffhunk://#diff-4cd404657dfc263af0e826d32015c634a2e0e727c10a4035c801e525ead6af3bL161-R159)