### PR TITLE
Added: Github actions publishing to PyPi

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1,0 +1,53 @@
+name: Upload Nitro CLI Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build release distributions
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nitro-cli/
+    needs:
+      - release-build
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+            password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test Nitro CLI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install ".[dev]"
+    - name: Lint with flake8
+      run: |
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ config = Config(
 
 Nitro isn’t just one library – it’s a growing toolkit of focused building blocks you can mix and match to ship faster:
 
-* **[nitro-ui](https://github.com/nitrosh/nitro-ui)** — Generate clean, reusable HTML with a lightweight, developer-friendly API
-* **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** — Load and access data effortlessly using simple dot-notation paths
-* **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** — A flexible plugin system to extend features without touching core code
-* **[nitro-validate](https://github.com/nitrosh/nitro-validate)** — Fast, reliable data validation to keep your inputs and payloads rock-solid
+* **[nitro-ui](https://github.com/nitrosh/nitro-ui)** - Generate clean, reusable HTML with a lightweight, developer-friendly API
+* **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** - Load and access data effortlessly using simple dot-notation paths
+* **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** - A flexible plugin system to extend features without touching core code
+* **[nitro-validate](https://github.com/nitrosh/nitro-validate)** - Fast, reliable data validation to keep your inputs and payloads rock-solid
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -177,11 +177,11 @@ Page(
 
 ### File Path to URL Mapping
 
-| File Path | Output URL |
-|-----------|------------|
-| `src/pages/index.py` | `/index.html` |
-| `src/pages/about.py` | `/about.html` |
-| `src/pages/blog/post.py` | `/blog/post.html` |
+| File Path                     | Output URL             |
+|-------------------------------|------------------------|
+| `src/pages/index.py`          | `/index.html`          |
+| `src/pages/about.py`          | `/about.html`          |
+| `src/pages/blog/post.py`      | `/blog/post.html`      |
 | `src/pages/docs/api/index.py` | `/docs/api/index.html` |
 
 ## nitro-ui HTML Module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nitro-cli"
 version = "1.0.0"
-description = "Static sites without the JavaScript fatigue"
+description = "Build static sites with Python code instead of templates"
 authors = [
     {name = "Sean Nieuwoudt", email = "sean@nitro.sh"}
 ]

--- a/src/nitro/templates/default/README.md
+++ b/src/nitro/templates/default/README.md
@@ -42,7 +42,7 @@ nitro preview
 
 Nitro isn’t just one library – it’s a growing toolkit of focused building blocks you can mix and match to ship faster:
 
-* **[nitro-ui](https://github.com/nitrosh/nitro-ui)** — Generate clean, reusable HTML with a lightweight, developer-friendly API
-* **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** — Load and access data effortlessly using simple dot-notation paths
-* **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** — A flexible plugin system to extend features without touching core code
-* **[nitro-validate](https://github.com/nitrosh/nitro-validate)** — Fast, reliable data validation to keep your inputs and payloads rock-solid
+* **[nitro-ui](https://github.com/nitrosh/nitro-ui)** - Generate clean, reusable HTML with a lightweight, developer-friendly API
+* **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** - Load and access data effortlessly using simple dot-notation paths
+* **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** - A flexible plugin system to extend features without touching core code
+* **[nitro-validate](https://github.com/nitrosh/nitro-validate)** - Fast, reliable data validation to keep your inputs and payloads rock-solid


### PR DESCRIPTION
This pull request introduces continuous integration (CI) and publishing workflows for the Nitro CLI project, along with minor documentation and metadata improvements. The main changes are the addition of GitHub Actions workflows for testing across multiple Python versions and for publishing releases to PyPI, as well as some documentation formatting and description updates.

**CI/CD Automation:**

* Added `.github/workflows/test.yml` to run linting and tests with `flake8` and `pytest` on pushes and pull requests to `main`, across Python 3.9–3.14.
* Added `.github/workflows/publishing.yml` to automate building and publishing Nitro CLI releases to PyPI when a GitHub release is published.

**Documentation and Metadata Updates:**

* Updated the project description in `pyproject.toml` for clarity, emphasizing building static sites with Python code.
* Standardized Markdown formatting for the list of related Nitro libraries in `README.md` and `src/nitro/templates/default/README.md` for consistency. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R112) [[2]](diffhunk://#diff-e30b92e21e47c8e6e35ce61882857bf7af0f4ea1a83a0d397d2793ceec66ab6dL45-R48)
* Fixed the Markdown table formatting in `SKILL.md` for better readability.