### PR TITLE
Updating the license to BSD

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,28 @@
-MIT License
+BSD 3-Clause License
 
-Copyright (c) Sean Nieuwoudt
+Copyright (c) 2024-2026 Sean Nieuwoudt
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd my-site
 nitro dev
 ```
 
-Visit http://localhost:3000. Build for production with `nitro build`.
+Visit <http://localhost:3000>. Build for production with `nitro build`.
 
 ## Writing Pages
 
@@ -104,13 +104,13 @@ config = Config(
 
 ## Ecosystem
 
-Nitro isn’t just one library – it’s a growing toolkit of focused building blocks you can mix and match to ship faster:
+Nitro isn’t just one library - it's a growing toolkit of focused building blocks you can mix and match to ship faster:
 
-* **[nitro-ui](https://github.com/nitrosh/nitro-ui)** - Generate clean, reusable HTML with a lightweight, developer-friendly API
-* **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** - Load and access data effortlessly using simple dot-notation paths
-* **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** - A flexible plugin system to extend features without touching core code
-* **[nitro-validate](https://github.com/nitrosh/nitro-validate)** - Fast, reliable data validation to keep your inputs and payloads rock-solid
+- **[nitro-ui](https://github.com/nitrosh/nitro-ui)** - Generate clean, reusable HTML with a lightweight, developer-friendly API
+- **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** - Load and access data effortlessly using simple dot-notation paths
+- **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** - A flexible plugin system to extend features without touching core code
+- **[nitro-validate](https://github.com/nitrosh/nitro-validate)** - Fast, reliable data validation to keep your inputs and payloads rock-solid
 
 ## License
 
-MIT
+This project is licensed under the BSD 3-Clause License. See the [LICENSE](LICENSE) file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nitro-cli"
-version = "1.0.0"
+version = "1.0.1"
 description = "Build static sites with Python code instead of templates"
 authors = [
     {name = "Sean Nieuwoudt", email = "sean@nitro.sh"}
 ]
-license = {text = "MIT"}
+license-files = ["LICEN[CS]E*"]
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = [

--- a/src/nitro/templates/default/README.md
+++ b/src/nitro/templates/default/README.md
@@ -40,9 +40,9 @@ nitro preview
 
 ## Ecosystem
 
-Nitro isn’t just one library – it’s a growing toolkit of focused building blocks you can mix and match to ship faster:
+Nitro isn’t just one library - it's a growing toolkit of focused building blocks you can mix and match to ship faster:
 
-* **[nitro-ui](https://github.com/nitrosh/nitro-ui)** - Generate clean, reusable HTML with a lightweight, developer-friendly API
-* **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** - Load and access data effortlessly using simple dot-notation paths
-* **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** - A flexible plugin system to extend features without touching core code
-* **[nitro-validate](https://github.com/nitrosh/nitro-validate)** - Fast, reliable data validation to keep your inputs and payloads rock-solid
+- **[nitro-ui](https://github.com/nitrosh/nitro-ui)** - Generate clean, reusable HTML with a lightweight, developer-friendly API
+- **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** - Load and access data effortlessly using simple dot-notation paths
+- **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** - A flexible plugin system to extend features without touching core code
+- **[nitro-validate](https://github.com/nitrosh/nitro-validate)** - Fast, reliable data validation to keep your inputs and payloads rock-solid


### PR DESCRIPTION
This pull request updates the project's licensing and documentation to reflect a switch from the MIT License to the BSD 3-Clause License, and makes minor improvements to documentation formatting and metadata. The most important changes are summarized below:

**Licensing changes:**

* Changed the project license from MIT License to BSD 3-Clause License in the `LICENSE` file, updating the copyright year and legal terms.
* Updated the license reference in `README.md` and `src/nitro/templates/default/README.md` to state the project is now under the BSD 3-Clause License, and added a link to the license file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R116) [[2]](diffhunk://#diff-e30b92e21e47c8e6e35ce61882857bf7af0f4ea1a83a0d397d2793ceec66ab6dL43-R48)
* Updated the `pyproject.toml` metadata to reference license files using a pattern that matches BSD license naming, replacing the previous MIT-specific field.

**Documentation and formatting improvements:**

* Improved link formatting and consistency in `README.md` and `src/nitro/templates/default/README.md`, including using angle brackets for URLs and standardizing list formatting. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R116) [[3]](diffhunk://#diff-e30b92e21e47c8e6e35ce61882857bf7af0f4ea1a83a0d397d2793ceec66ab6dL43-R48)
* Minor version bump in `pyproject.toml` to reflect these changes.