### PR TITLE
Fixed: incorrect handling of the bundle generator fingerprinting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nitro-cli"
-version = "1.0.1"
+version = "1.0.2"
 description = "Build static sites with Python code instead of templates"
 authors = [
     {name = "Sean Nieuwoudt", email = "sean@nitro.sh"}

--- a/src/nitro/core/generator.py
+++ b/src/nitro/core/generator.py
@@ -396,11 +396,16 @@ class Generator:
             styles_dest = self.build_dir / "assets" / "styles"
             self._copy_directory(styles_src, styles_dest, "styles", verbose)
 
-        # Copy public files
+        # Copy public files (src/public/ -> build/)
         public_src = self.source_dir / "public"
         if public_src.exists():
             # Copy public files to root of build directory
             self._copy_directory(public_src, self.build_dir, "public", verbose)
+
+        # Copy static files (static/ -> build/)
+        static_src = self.project_root / "static"
+        if static_src.exists():
+            self._copy_directory(static_src, self.build_dir, "static", verbose)
 
     def _copy_directory(
         self, src: Path, dest: Path, name: str, verbose: bool = False


### PR DESCRIPTION
This pull request introduces improvements to asset handling and build processes in the `nitro-cli` project. The main changes focus on enhancing asset fingerprinting by using regex-based replacements, supporting static file copying, and incrementing the project version.

**Asset handling improvements:**

* Updated the asset fingerprinting logic in `bundler.py` to use regular expressions for replacing asset paths in HTML. This makes the replacement more robust, handling quoted, unquoted, and minified attribute formats, and reduces the risk of missing or incorrect replacements.
* Added `import re` to `bundler.py` to support the new regex-based logic.

**Build process enhancements:**

* Modified the asset copying logic in `generator.py` to support copying the `static/` directory from the project root to the build directory, in addition to existing support for `public/` files. This allows users to include static assets more flexibly.

**Version update:**

* Bumped the project version from `1.0.1` to `1.0.2` in `pyproject.toml` to reflect these changes.