### PR TITLE
Fixed: Rich 14.x changed the internal handling of markup strings in certain contexts.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nitro-cli"
-version = "1.0.2"
+version = "1.0.3"
 description = "Build static sites with Python code instead of templates"
 authors = [
     {name = "Sean Nieuwoudt", email = "sean@nitro.sh"}

--- a/src/nitro/commands/info.py
+++ b/src/nitro/commands/info.py
@@ -8,6 +8,7 @@ import click
 from rich.table import Table
 from rich.panel import Panel
 from rich.box import ROUNDED
+from rich.text import Text
 
 from ..core.config import load_config
 from ..core.page import get_project_root
@@ -44,7 +45,7 @@ def _output_rich(project_root):
     env_table.add_row("Platform", platform.system())
     env_table.add_row("Architecture", platform.machine())
 
-    console.print(Panel(env_table, title="[bold]Environment[/]", border_style="blue"))
+    console.print(Panel(env_table, title=Text.from_markup("[bold]Environment[/]"), border_style="blue"))
 
     if project_root:
         config_path = project_root / "nitro.config.py"
@@ -67,7 +68,7 @@ def _output_rich(project_root):
                 proj_table.add_row("Plugins", ", ".join(config.plugins))
 
             console.print(
-                Panel(proj_table, title="[bold]Project[/]", border_style="green")
+                Panel(proj_table, title=Text.from_markup("[bold]Project[/]"), border_style="green")
             )
 
             _show_directory_stats(project_root, config)
@@ -75,7 +76,7 @@ def _output_rich(project_root):
             console.print(
                 Panel(
                     f"[dim]Project root:[/] {project_root}\n[yellow]No nitro.config.py found[/]",
-                    title="[bold]Project[/]",
+                    title=Text.from_markup("[bold]Project[/]"),
                     border_style="yellow",
                 )
             )
@@ -83,7 +84,7 @@ def _output_rich(project_root):
         console.print(
             Panel(
                 "[yellow]Not inside a Nitro project[/]\n[dim]Run 'nitro new <name>' to create one[/]",
-                title="[bold]Project[/]",
+                title=Text.from_markup("[bold]Project[/]"),
                 border_style="yellow",
             )
         )
@@ -131,7 +132,7 @@ def _show_directory_stats(project_root: Path, config):
 
     if stats_table.row_count > 0:
         console.print(
-            Panel(stats_table, title="[bold]Statistics[/]", border_style="cyan")
+            Panel(stats_table, title=Text.from_markup("[bold]Statistics[/]"), border_style="cyan")
         )
 
 
@@ -162,7 +163,7 @@ def _show_dependencies():
             deps_table.add_row(display_name, "-", "[red]✗ missing[/]")
 
     console.print(
-        Panel(deps_table, title="[bold]Dependencies[/]", border_style="magenta")
+        Panel(deps_table, title=Text.from_markup("[bold]Dependencies[/]"), border_style="magenta")
     )
 
 

--- a/src/nitro/core/generator.py
+++ b/src/nitro/core/generator.py
@@ -172,7 +172,7 @@ class Generator:
                 # Parallel generation
                 progress.update(
                     task,
-                    description=f"[cyan]Generating {len(pages_to_build)} pages ({max_workers} workers)[/]",
+                    description=f"Generating {len(pages_to_build)} pages ({max_workers} workers)",
                 )
 
                 with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -206,7 +206,7 @@ class Generator:
                 for page_path in pages_to_build:
                     # Update progress description with current file
                     relative_path = page_path.relative_to(self.project_root)
-                    progress.update(task, description=f"[cyan]{relative_path}[/]")
+                    progress.update(task, description=str(relative_path))
 
                     if verbose:
                         console.print(f"  Processing: {relative_path}")

--- a/src/nitro/utils/logger.py
+++ b/src/nitro/utils/logger.py
@@ -94,7 +94,7 @@ def error_panel(
     if hint:
         content.append(f"\n  Hint: {hint}\n", style="cyan")
 
-    console.print(Panel(content, title=f"[bold red]{title}[/]", border_style="red"))
+    console.print(Panel(content, title=Text.from_markup(f"[bold red]{title}[/]"), border_style="red"))
 
 
 def step(current: int, total: int, message: str) -> None:
@@ -165,7 +165,7 @@ def server_panel(host: str, port: int, live_reload: bool = True) -> None:
   Live Reload: [green]{"enabled" if live_reload else "disabled"}[/]
 """
     console.print(
-        Panel(content, title="[bold]Development Server[/]", border_style="green")
+        Panel(content, title=Text.from_markup("[bold]Development Server[/]"), border_style="green")
     )
 
 
@@ -197,7 +197,7 @@ def build_summary(stats: dict, elapsed: str) -> None:
     )
     content = f"\n  Files: {count}\n  Size:  {size}\n  Time:  {elapsed}\n"
     console.print(
-        Panel(content, title="[bold green]Build Complete[/]", border_style="green")
+        Panel(content, title=Text.from_markup("[bold green]Build Complete[/]"), border_style="green")
     )
 
 
@@ -217,7 +217,7 @@ def scaffold_complete(project_name: str) -> None:
   [cyan]nitro dev[/]
 """
     console.print(
-        Panel(content, title="[bold green]Project Created[/]", border_style="green")
+        Panel(content, title=Text.from_markup("[bold green]Project Created[/]"), border_style="green")
     )
 
 


### PR DESCRIPTION
This pull request updates the `nitro-cli` project to version 1.0.3 and focuses on improving the way panel titles are rendered throughout the CLI by consistently using `Text.from_markup` from the Rich library. This change ensures that all panel titles are correctly parsed and styled as markup, which improves consistency and avoids potential rendering issues. Additionally, minor adjustments were made to progress descriptions to remove unnecessary markup.

Panel title rendering improvements:

* Replaced string-based panel titles with `Text.from_markup` in all relevant panels within `src/nitro/commands/info.py`, including Environment, Project, Statistics, and Dependencies sections. [[1]](diffhunk://#diff-66ab495d9e451d83d27f913fcca807e9824ad0ca8562908bfd43d7ae6463128aL47-R48) [[2]](diffhunk://#diff-66ab495d9e451d83d27f913fcca807e9824ad0ca8562908bfd43d7ae6463128aL70-R87) [[3]](diffhunk://#diff-66ab495d9e451d83d27f913fcca807e9824ad0ca8562908bfd43d7ae6463128aL134-R135) [[4]](diffhunk://#diff-66ab495d9e451d83d27f913fcca807e9824ad0ca8562908bfd43d7ae6463128aL165-R166)
* Updated panel titles in `src/nitro/utils/logger.py` to use `Text.from_markup` for error, server, build summary, and scaffold complete messages. [[1]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L97-R97) [[2]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L168-R168) [[3]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L200-R200) [[4]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L220-R220)

General improvements:

* Added `from rich.text import Text` import to support the new panel title rendering approach in `src/nitro/commands/info.py`.
* Updated progress bar descriptions in `src/nitro/core/generator.py` to remove unnecessary markup, ensuring plain text is used for better clarity. [[1]](diffhunk://#diff-e40e59598b79738293b149d0d91158b718c3a5511043d265ba93ed65de73deb4L175-R175) [[2]](diffhunk://#diff-e40e59598b79738293b149d0d91158b718c3a5511043d265ba93ed65de73deb4L209-R209)

Project version update:

* Bumped the `nitro-cli` version from 1.0.2 to 1.0.3 in `pyproject.toml` to reflect these changes.