### PR TITLE
Fix Rich Progress crash during HMR live reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,10 @@ config = Config(
 
 ## Ecosystem
 
-Nitro isn’t just one library - it's a growing toolkit of focused building blocks you can mix and match to ship faster:
-
-- **[nitro-ui](https://github.com/nitrosh/nitro-ui)** - Generate clean, reusable HTML with a lightweight, developer-friendly API
-- **[nitro-datastore](https://github.com/nitrosh/nitro-datastore)** - Load and access data effortlessly using simple dot-notation paths
-- **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** - A flexible plugin system to extend features without touching core code
-- **[nitro-validate](https://github.com/nitrosh/nitro-validate)** - Fast, reliable data validation to keep your inputs and payloads rock-solid
+- **[nitro-ui](https://github.com/nitrosh/nitro-ui)** - Programmatic HTML generation
+- **[nitro-cli](https://github.com/nitrosh/nitro-cli)** - Static site generator
+- **[nitro-dispatch](https://github.com/nitrosh/nitro-dispatch)** - Plugin system
+- **[nitro-validate](https://github.com/nitrosh/nitro-validate)** - Data validation
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nitro-cli"
-version = "1.0.3"
+version = "1.0.4"
 description = "Build static sites with Python code instead of templates"
 authors = [
     {name = "Sean Nieuwoudt", email = "sean@nitro.sh"}

--- a/src/nitro/commands/serve.py
+++ b/src/nitro/commands/serve.py
@@ -71,7 +71,9 @@ async def serve_async(
     ):
         with spinner("Generating site...") as update:
             # Run blocking generation in thread pool to avoid blocking event loop
-            success_result = await asyncio.to_thread(generator.generate, verbose=False)
+            success_result = await asyncio.to_thread(
+                generator.generate, verbose=False, quiet=True
+            )
             if not success_result:
                 error_panel(
                     "Generation Failed",
@@ -122,7 +124,9 @@ async def serve_async(
                             should_notify = True
                 elif "components" in str(path):
                     hmr_update("site", "rebuilding...")
-                    if await asyncio.to_thread(generator.generate, verbose=False):
+                    if await asyncio.to_thread(
+                        generator.generate, verbose=False, quiet=True
+                    ):
                         should_notify = True
                 elif "styles" in str(path) or "public" in str(path):
                     hmr_update("assets", "rebuilding...")
@@ -131,11 +135,15 @@ async def serve_async(
                 elif path.name == "nitro.config.py":
                     hmr_update("config", "rebuilding...")
                     generator = Generator()
-                    if await asyncio.to_thread(generator.generate, verbose=False):
+                    if await asyncio.to_thread(
+                        generator.generate, verbose=False, quiet=True
+                    ):
                         should_notify = True
                 else:
                     hmr_update("site", "rebuilding...")
-                    if await asyncio.to_thread(generator.generate, verbose=False):
+                    if await asyncio.to_thread(
+                        generator.generate, verbose=False, quiet=True
+                    ):
                         should_notify = True
 
                 if should_notify:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,317 @@
+"""Tests for core/generator.py."""
+
+import pytest
+from pathlib import Path
+import tempfile
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from nitro.core.generator import Generator
+from nitro.core.config import Config
+
+
+class TestGeneratorInit:
+    """Tests for Generator initialization."""
+
+    def test_default_initialization(self):
+        """Generator should initialize with defaults."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "src" / "pages").mkdir(parents=True)
+
+            generator = Generator(project_root=project_root)
+
+            assert generator.project_root == project_root
+            assert generator.source_dir == project_root / "src"
+            assert generator.build_dir == project_root / "build"
+
+    def test_with_config_file(self):
+        """Generator should load config from nitro.config.py."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "src" / "pages").mkdir(parents=True)
+
+            # Create config file
+            config_file = project_root / "nitro.config.py"
+            config_file.write_text(
+                """from nitro import Config
+config = Config(site_name="Test Site", build_dir="dist")
+"""
+            )
+
+            generator = Generator(project_root=project_root)
+
+            assert generator.config.site_name == "Test Site"
+            assert generator.build_dir == project_root / "dist"
+
+
+class TestGenerateQuietMode:
+    """Tests for generate() with quiet parameter."""
+
+    def _create_test_project(self, tmpdir: Path) -> Path:
+        """Helper to create a minimal test project."""
+        project_root = tmpdir
+        pages_dir = project_root / "src" / "pages"
+        pages_dir.mkdir(parents=True)
+
+        # Create a simple page
+        page_file = pages_dir / "index.py"
+        page_file.write_text(
+            """
+from nitro.core.page import Page
+
+def render():
+    return Page(title="Test", content="<h1>Hello</h1>")
+"""
+        )
+
+        # Create config
+        config_file = project_root / "nitro.config.py"
+        config_file.write_text(
+            """from nitro import Config
+config = Config()
+"""
+        )
+
+        return project_root
+
+    def test_generate_with_quiet_true(self):
+        """generate() should work with quiet=True."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = self._create_test_project(Path(tmpdir))
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            result = generator.generate(verbose=False, quiet=True)
+
+            assert result is True
+            assert (project_root / "build" / "index.html").exists()
+
+    def test_generate_with_quiet_false(self):
+        """generate() should work with quiet=False (default)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = self._create_test_project(Path(tmpdir))
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            result = generator.generate(verbose=False, quiet=False)
+
+            assert result is True
+            assert (project_root / "build" / "index.html").exists()
+
+    def test_generate_quiet_default_is_false(self):
+        """quiet parameter should default to False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = self._create_test_project(Path(tmpdir))
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            # Call without quiet parameter - should use default (False)
+            result = generator.generate(verbose=False)
+
+            assert result is True
+
+    def test_generate_quiet_in_thread(self):
+        """generate(quiet=True) should work when called from a background thread."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = self._create_test_project(Path(tmpdir))
+
+            generator = Generator(project_root=project_root, use_cache=False)
+
+            # Simulate HMR scenario: run generate in a thread
+            result_holder = {"result": None, "error": None}
+
+            def run_generate():
+                try:
+                    result_holder["result"] = generator.generate(
+                        verbose=False, quiet=True
+                    )
+                except Exception as e:
+                    result_holder["error"] = e
+
+            thread = threading.Thread(target=run_generate)
+            thread.start()
+            thread.join(timeout=10)
+
+            assert result_holder["error"] is None, f"Error in thread: {result_holder['error']}"
+            assert result_holder["result"] is True
+
+    def test_generate_quiet_in_thread_pool(self):
+        """generate(quiet=True) should work in ThreadPoolExecutor."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = self._create_test_project(Path(tmpdir))
+
+            generator = Generator(project_root=project_root, use_cache=False)
+
+            # Simulate asyncio.to_thread scenario
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(generator.generate, verbose=False, quiet=True)
+                result = future.result(timeout=10)
+
+            assert result is True
+            assert (project_root / "build" / "index.html").exists()
+
+
+class TestGeneratePagesHelpers:
+    """Tests for _generate_pages_quiet and _generate_pages_with_progress."""
+
+    def _create_multi_page_project(self, tmpdir: Path, num_pages: int = 5) -> Path:
+        """Helper to create a project with multiple pages."""
+        project_root = tmpdir
+        pages_dir = project_root / "src" / "pages"
+        pages_dir.mkdir(parents=True)
+
+        # Create multiple pages
+        for i in range(num_pages):
+            page_file = pages_dir / f"page{i}.py"
+            page_file.write_text(
+                f"""
+from nitro.core.page import Page
+
+def render():
+    return Page(title="Page {i}", content="<h1>Page {i}</h1>")
+"""
+            )
+
+        # Create config
+        config_file = project_root / "nitro.config.py"
+        config_file.write_text(
+            """from nitro import Config
+config = Config()
+"""
+        )
+
+        return project_root
+
+    def test_generate_pages_quiet_sequential(self):
+        """_generate_pages_quiet should work with sequential generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = self._create_multi_page_project(Path(tmpdir), num_pages=2)
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            pages = generator._find_pages()
+
+            # Force sequential (use_parallel=False)
+            success_count, failed_pages = generator._generate_pages_quiet(
+                pages, use_parallel=False, max_workers=1, verbose=False
+            )
+
+            assert success_count == 2
+            assert len(failed_pages) == 0
+
+    def test_generate_pages_quiet_parallel(self):
+        """_generate_pages_quiet should work with parallel generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Need at least 4 pages for parallel mode to kick in
+            project_root = self._create_multi_page_project(Path(tmpdir), num_pages=5)
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            pages = generator._find_pages()
+
+            success_count, failed_pages = generator._generate_pages_quiet(
+                pages, use_parallel=True, max_workers=2, verbose=False
+            )
+
+            assert success_count == 5
+            assert len(failed_pages) == 0
+
+    def test_generate_pages_with_progress_sequential(self):
+        """_generate_pages_with_progress should work with sequential generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = self._create_multi_page_project(Path(tmpdir), num_pages=2)
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            pages = generator._find_pages()
+
+            success_count, failed_pages = generator._generate_pages_with_progress(
+                pages, use_parallel=False, max_workers=1, verbose=False
+            )
+
+            assert success_count == 2
+            assert len(failed_pages) == 0
+
+    def test_generate_pages_with_progress_parallel(self):
+        """_generate_pages_with_progress should work with parallel generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = self._create_multi_page_project(Path(tmpdir), num_pages=5)
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            pages = generator._find_pages()
+
+            success_count, failed_pages = generator._generate_pages_with_progress(
+                pages, use_parallel=True, max_workers=2, verbose=False
+            )
+
+            assert success_count == 5
+            assert len(failed_pages) == 0
+
+
+class TestRenderPageSequential:
+    """Tests for _render_page_sequential method."""
+
+    def test_renders_valid_page(self):
+        """Should render a valid page and write output."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            pages_dir = project_root / "src" / "pages"
+            pages_dir.mkdir(parents=True)
+
+            page_file = pages_dir / "test.py"
+            page_file.write_text(
+                """
+from nitro.core.page import Page
+
+def render():
+    return Page(title="Test", content="<p>Content</p>")
+"""
+            )
+
+            (project_root / "nitro.config.py").write_text(
+                "from nitro import Config\nconfig = Config()"
+            )
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            generator.build_dir.mkdir(parents=True, exist_ok=True)
+
+            result = generator._render_page_sequential(page_file, verbose=False)
+
+            assert result is True
+            assert (generator.build_dir / "test.html").exists()
+
+    def test_returns_false_for_invalid_page(self):
+        """Should return False for page without render function."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            pages_dir = project_root / "src" / "pages"
+            pages_dir.mkdir(parents=True)
+
+            page_file = pages_dir / "bad.py"
+            page_file.write_text("x = 1  # No render function")
+
+            (project_root / "nitro.config.py").write_text(
+                "from nitro import Config\nconfig = Config()"
+            )
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            generator.build_dir.mkdir(parents=True, exist_ok=True)
+
+            result = generator._render_page_sequential(page_file, verbose=False)
+
+            assert result is False
+
+
+class TestGenerateNoPages:
+    """Tests for generate() edge cases."""
+
+    def test_generate_returns_false_without_pages(self):
+        """generate() should return False when no pages exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            (project_root / "src" / "pages").mkdir(parents=True)
+
+            (project_root / "nitro.config.py").write_text(
+                "from nitro import Config\nconfig = Config()"
+            )
+
+            generator = Generator(project_root=project_root, use_cache=False)
+            result = generator.generate(verbose=False, quiet=True)
+
+            assert result is False


### PR DESCRIPTION
This pull request introduces a new "quiet mode" for site generation, allowing background processes (like the dev server) to suppress progress bar output for cleaner logs. The changes refactor the page generation logic to support both quiet and interactive modes, improve code structure by separating progress bar handling, and update documentation to reflect the current Nitro ecosystem.

**Site Generation Improvements**
- Added a `quiet` parameter to the `Generator.generate()` method and related code paths, allowing background site generation without printing progress bars or extraneous output. This is now used by the dev server's hot reload logic. [[1]](diffhunk://#diff-e40e59598b79738293b149d0d91158b718c3a5511043d265ba93ed65de73deb4L73-R85) [[2]](diffhunk://#diff-39decf380dc6290c2921ef6d6a217c2e110b43ff151986ddb8c9ce445267a10cL74-R76) [[3]](diffhunk://#diff-39decf380dc6290c2921ef6d6a217c2e110b43ff151986ddb8c9ce445267a10cL125-R129) [[4]](diffhunk://#diff-39decf380dc6290c2921ef6d6a217c2e110b43ff151986ddb8c9ce445267a10cL134-R146)
- Refactored the page generation logic into two distinct methods: `_generate_pages_quiet` (for background/quiet mode) and `_generate_pages_with_progress` (for interactive/foreground usage), improving code clarity and maintainability. [[1]](diffhunk://#diff-e40e59598b79738293b149d0d91158b718c3a5511043d265ba93ed65de73deb4R166-R307) [[2]](diffhunk://#diff-e40e59598b79738293b149d0d91158b718c3a5511043d265ba93ed65de73deb4L172-L194)
- Extracted single-page rendering into a new `_render_page_sequential` method for reuse and clarity, and updated error handling/reporting for both sequential and parallel builds. [[1]](diffhunk://#diff-e40e59598b79738293b149d0d91158b718c3a5511043d265ba93ed65de73deb4L205-L217) [[2]](diffhunk://#diff-e40e59598b79738293b149d0d91158b718c3a5511043d265ba93ed65de73deb4L227) [[3]](diffhunk://#diff-e40e59598b79738293b149d0d91158b718c3a5511043d265ba93ed65de73deb4L239-R410)

**Documentation and Metadata Updates**
- Updated the ecosystem section in `README.md` to reflect the current set of Nitro libraries, removing outdated descriptions and adding `nitro-cli` as the static site generator.
- Bumped the package version to `1.0.4` in `pyproject.toml`.