### PR TITLE
Fixed the Click (and other libraries) are deprecating the __version__ module attribute pattern

### DIFF
--- a/src/nitro/commands/info.py
+++ b/src/nitro/commands/info.py
@@ -138,29 +138,30 @@ def _show_directory_stats(project_root: Path, config):
 
 def _show_dependencies():
     """Show installed Nitro ecosystem dependencies."""
+    from importlib.metadata import version as pkg_version, PackageNotFoundError
+
     deps_table = Table(box=ROUNDED, show_header=True, padding=(0, 2), expand=False)
     deps_table.add_column("Package", style="dim")
     deps_table.add_column("Version", style="cyan")
     deps_table.add_column("Status", style="green")
 
     packages = [
-        ("nitro-ui", "nitro_ui"),
-        ("nitro-datastore", "nitro_datastore"),
-        ("nitro-dispatch", "nitro_dispatch"),
-        ("click", "click"),
-        ("rich", "rich"),
-        ("watchdog", "watchdog"),
-        ("aiohttp", "aiohttp"),
-        ("pillow", "PIL"),
+        "nitro-ui",
+        "nitro-datastore",
+        "nitro-dispatch",
+        "click",
+        "rich",
+        "watchdog",
+        "aiohttp",
+        "pillow",
     ]
 
-    for display_name, import_name in packages:
+    for package_name in packages:
         try:
-            module = __import__(import_name)
-            version = getattr(module, "__version__", "installed")
-            deps_table.add_row(display_name, str(version), "✓")
-        except ImportError:
-            deps_table.add_row(display_name, "-", "[red]✗ missing[/]")
+            version = pkg_version(package_name)
+            deps_table.add_row(package_name, version, "✓")
+        except PackageNotFoundError:
+            deps_table.add_row(package_name, "-", "[red]✗ missing[/]")
 
     console.print(
         Panel(deps_table, title=Text.from_markup("[bold]Dependencies[/]"), border_style="magenta")

--- a/src/nitro/utils/logger.py
+++ b/src/nitro/utils/logger.py
@@ -81,20 +81,35 @@ def error_panel(
     line: Optional[int] = None,
     hint: Optional[str] = None,
 ) -> None:
-    """Display a formatted error panel."""
-    content = Text()
-    content.append(f"\n  {message}\n", style="red")
+    """Display a formatted error panel.
 
-    if file_path:
-        location = f"\n  File: {file_path}"
-        if line:
-            location += f", line {line}"
-        content.append(location + "\n", style="dim")
+    Falls back to simple text output if Rich rendering fails
+    (e.g., when running in background threads without TTY).
+    """
+    try:
+        content = Text()
+        content.append(f"\n  {message}\n", style="red")
 
-    if hint:
-        content.append(f"\n  Hint: {hint}\n", style="cyan")
+        if file_path:
+            location = f"\n  File: {file_path}"
+            if line:
+                location += f", line {line}"
+            content.append(location + "\n", style="dim")
 
-    console.print(Panel(content, title=Text.from_markup(f"[bold red]{title}[/]"), border_style="red"))
+        if hint:
+            content.append(f"\n  Hint: {hint}\n", style="cyan")
+
+        console.print(Panel(content, title=f"[bold red]{title}[/]", border_style="red"))
+    except Exception:
+        # Fallback for background threads or non-TTY environments
+        print(f"\n✗ {title}: {message}")
+        if file_path:
+            location = f"  File: {file_path}"
+            if line:
+                location += f", line {line}"
+            print(location)
+        if hint:
+            print(f"  Hint: {hint}")
 
 
 def step(current: int, total: int, message: str) -> None:
@@ -165,7 +180,7 @@ def server_panel(host: str, port: int, live_reload: bool = True) -> None:
   Live Reload: [green]{"enabled" if live_reload else "disabled"}[/]
 """
     console.print(
-        Panel(content, title=Text.from_markup("[bold]Development Server[/]"), border_style="green")
+        Panel(content, title="[bold]Development Server[/]", border_style="green")
     )
 
 
@@ -197,7 +212,7 @@ def build_summary(stats: dict, elapsed: str) -> None:
     )
     content = f"\n  Files: {count}\n  Size:  {size}\n  Time:  {elapsed}\n"
     console.print(
-        Panel(content, title=Text.from_markup("[bold green]Build Complete[/]"), border_style="green")
+        Panel(content, title="[bold green]Build Complete[/]", border_style="green")
     )
 
 
@@ -217,7 +232,7 @@ def scaffold_complete(project_name: str) -> None:
   [cyan]nitro dev[/]
 """
     console.print(
-        Panel(content, title=Text.from_markup("[bold green]Project Created[/]"), border_style="green")
+        Panel(content, title="[bold green]Project Created[/]", border_style="green")
     )
 
 


### PR DESCRIPTION
This pull request improves error handling and robustness in the Nitro project, especially for background threads and non-TTY environments. It ensures that errors during code generation do not crash the process, even when running in quiet mode or in threads, and provides fallback logging. Additionally, it simplifies package version detection and improves test coverage for threaded error scenarios.

**Error handling improvements:**

* Updated the `error_panel` function in `logger.py` to gracefully fall back to simple text output if Rich rendering fails, such as when running in background threads or non-TTY environments. This prevents crashes and ensures errors are still reported. [[1]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L84-R89) [[2]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L97-R112)
* Added a new test class `TestErrorHandlingInQuietMode` in `test_generator.py` to verify that syntax errors, name errors, and import errors during generation in background threads are handled gracefully, do not crash the process, and allow generation to complete. Also tests mixed valid/invalid pages.

**Dependency/version reporting:**

* Simplified the `_show_dependencies` function in `info.py` to use `importlib.metadata.version` for retrieving package versions, removing manual imports and improving reliability of version detection.

**UI/console output consistency:**

* Standardized the use of panel titles in `logger.py` by removing `Text.from_markup` in favor of plain strings, improving compatibility and consistency for panels such as server info, build summary, and scaffold completion. [[1]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L168-R183) [[2]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L200-R215) [[3]](diffhunk://#diff-d382a4c0deff3ae9cf9b62e3d469065097796ed20d1b773d083fee8af9fbc0b1L220-R235)